### PR TITLE
fix: remove placeholder Codecov token

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Release](https://github.com/soulcorrea/lucide-svg-rs/actions/workflows/release.yml/badge.svg)](https://github.com/soulcorrea/lucide-svg-rs/actions/workflows/release.yml)
 [![Crates.io](https://img.shields.io/crates/v/lucide-svg-rs.svg)](https://crates.io/crates/lucide-svg-rs)
 [![Docs.rs](https://docs.rs/lucide-svg-rs/badge.svg)](https://docs.rs/lucide-svg-rs)
-[![codecov](https://codecov.io/gh/soulcorrea/lucide-svg-rs/branch/main/graph/badge.svg?token=YOURTOKEN)](https://codecov.io/gh/soulcorrea/lucide-svg-rs)
+[![codecov](https://codecov.io/gh/soulcorrea/lucide-svg-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/soulcorrea/lucide-svg-rs)
 
 lucide-svg-rs is a Rust library + command-line tool for working with
 [Lucide](https://lucide.dev) SVG icons **offline**.  


### PR DESCRIPTION
## Summary
- fix Codecov badge URL to drop placeholder token

## Testing
- `cargo test`
- `curl -L https://codecov.io/gh/soulcorrea/lucide-svg-rs/branch/main/graph/badge.svg -o /tmp/badge.svg` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ada8ef64088328be4d448db1115f2b